### PR TITLE
patch: 1.4.0 - logConfig-in-messageObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ loglady 🪵 is built with extensibility in mind. A new log destination can be c
 The `MessageObject` is the object that is sent to each log destination. It contains the following properties:
 - `messageTemplate`: The message template
 - `message`: The formatted message (with parameters applied if any)
-- `properties`: An object containing additional properties (e.g. runtime information, parameters and calling information)
+- `properties`: An object containing additional properties (e.g. runtime information, parameters, calling information and potential logConfig)
 - `exception`: An optional exception object (if passed to the errorException log function)
 
 ### Runtime information

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -48,9 +48,16 @@ export class Logger {
       properties["EnvironmentName"] = this._runtimeInfo.environmentName;
     }
 
-    if (logConfig.contextId) {
-      properties["ContextId"] = logConfig.contextId;
-    }
+    // Add logConfig properties in PascalCase to properties
+    Object.entries(logConfig).forEach(([key, value]: [string, string | undefined]): void => {
+      if (!value) {
+        return;
+      }
+
+      const pascalCase: string = key.charAt(0).toUpperCase() + key.slice(1);
+      properties[pascalCase] = value;
+      console.log(`'${pascalCase}' added to properties with value: '${value}'`);
+    });
 
     const callingInfo: CallingInfo | undefined = this.getCallingInfo();
     if (callingInfo !== undefined) {


### PR DESCRIPTION
### Patch commits:
- patch: Add properties from `logConfig` into **messageObject.properties** (Closes #30) (4e26606)

### Maintenance commits:
- chore: Correct example for using `runInContext<T>` (546f67f)
