### PR TITLE
patch: 1.5.2 - include-message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vestfoldfylke/loglady",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vestfoldfylke/loglady",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "2.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vestfoldfylke/loglady",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
   "browser": "./dist/browser/index.js",

--- a/src/destinations/BetterStack/index.ts
+++ b/src/destinations/BetterStack/index.ts
@@ -5,6 +5,8 @@ import type { LogDestination } from "../../types/LogDestination.types";
 import type { LogLevel, MessageObject, TrackedPromise } from "../../types/log.types";
 import type { MinimalPackage } from "../../types/minimal-package.types";
 
+import { colors } from "../Console/ansi-console.js";
+
 // noinspection JSUnusedGlobalSymbols
 /**
  * @internal
@@ -58,7 +60,7 @@ export default class BetterStackDestination implements LogDestination {
       };
     }
 
-    const betterStackMessage: BetterStackPayload = this.createPayload<BetterStackPayload>(messageObject, level);
+    const messagePayload: BetterStackPayload = this.createPayload<BetterStackPayload>(messageObject, level);
 
     const promise: Promise<Response> = fetch(this._endpoint as string, {
       method: "POST",
@@ -67,7 +69,7 @@ export default class BetterStackDestination implements LogDestination {
         "Content-Type": "application/json",
         Authorization: `Bearer ${this._token}`
       },
-      body: JSON.stringify(betterStackMessage)
+      body: JSON.stringify(messagePayload)
     });
 
     const trackedPromise: TrackedPromise = {
@@ -77,7 +79,14 @@ export default class BetterStackDestination implements LogDestination {
     };
 
     promise
-      .catch((error: unknown) => console.error(`Failed to log message to ${this.name}`, "--->", error))
+      .catch((error: unknown) =>
+        console.error(
+          `${colors.fgRed}Failed to log message to ${this.name}. Message:${colors.reset}`,
+          messagePayload,
+          `${colors.fgRed}--->${colors.reset}`,
+          error
+        )
+      )
       .finally((): void => {
         trackedPromise.isSettled = true;
       });

--- a/src/destinations/Console/ansi-console.ts
+++ b/src/destinations/Console/ansi-console.ts
@@ -1,22 +1,25 @@
-const reset: string = "\u001b[0m";
+import type { ConsoleColors } from "../../types/log.types";
 
-const fgRed: string = "\u001b[31m";
-const fgYellow: string = "\u001b[33m";
-const fgCyan: string = "\u001b[36m";
-const fgWhite: string = "\u001b[37m";
+export const colors: ConsoleColors = {
+  reset: "\u001b[0m",
+  fgRed: "\u001b[31m",
+  fgYellow: "\u001b[33m",
+  fgCyan: "\u001b[36m",
+  fgWhite: "\u001b[37m"
+};
 
 export const colorDebug = (...args: string[]): void => {
-  console.debug(fgCyan, ...args, reset);
+  console.debug(colors.fgCyan, ...args, colors.reset);
 };
 
 export const colorInfo = (...args: string[]): void => {
-  console.info(fgWhite, ...args, reset);
+  console.info(colors.fgWhite, ...args, colors.reset);
 };
 
 export const colorWarn = (...args: string[]): void => {
-  console.warn(fgYellow, ...args, reset);
+  console.warn(colors.fgYellow, ...args, colors.reset);
 };
 
-export const colorError = (...args: string[]): void => {
-  console.error(fgRed, ...args, reset);
+export const colorError = (...args: unknown[]): void => {
+  console.error(colors.fgRed, ...args, colors.reset);
 };

--- a/src/destinations/Console/index.ts
+++ b/src/destinations/Console/index.ts
@@ -57,28 +57,28 @@ export default class ConsoleDestination implements LogDestination {
       };
     }
 
-    const payload: ConsolePayload = this.createPayload<ConsolePayload>(messageObject, level);
+    const messagePayload: ConsolePayload = this.createPayload<ConsolePayload>(messageObject, level);
 
     switch (level) {
       case "DEBUG":
-        colorDebug(...payload);
+        colorDebug(...messagePayload);
         break;
       case "INFO":
-        colorInfo(...payload);
+        colorInfo(...messagePayload);
         break;
       case "WARN":
-        colorWarn(...payload);
+        colorWarn(...messagePayload);
         break;
       case "ERROR":
         if (messageObject.exception !== undefined) {
-          colorError(...payload, "--->", messageObject.exception);
+          colorError(...messagePayload, "--->", messageObject.exception);
           break;
         }
 
-        colorError(...payload);
+        colorError(...messagePayload);
         break;
       default:
-        colorInfo(...payload);
+        colorInfo(...messagePayload);
     }
 
     return {

--- a/src/destinations/Microsoft Teams/index.ts
+++ b/src/destinations/Microsoft Teams/index.ts
@@ -10,6 +10,8 @@ import type { LogDestination } from "../../types/LogDestination.types";
 import type { LogLevel, MessageObject, MessageObjectProperties, MessageParameter, TrackedPromise } from "../../types/log.types";
 import type { MinimalPackage } from "../../types/minimal-package.types";
 
+import { colors } from "../Console/ansi-console";
+
 // noinspection JSUnusedGlobalSymbols
 /**
  * @internal
@@ -238,7 +240,7 @@ export default class MicrosoftTeamsDestination implements LogDestination {
       };
     }
 
-    const payload: MicrosoftTeamsPayload = this.createPayload<MicrosoftTeamsPayload>(messageObject, level);
+    const messagePayload: MicrosoftTeamsPayload = this.createPayload<MicrosoftTeamsPayload>(messageObject, level);
 
     const promise: Promise<Response> = fetch(this._webhookUrl as string, {
       method: "POST",
@@ -246,7 +248,7 @@ export default class MicrosoftTeamsDestination implements LogDestination {
       headers: {
         "Content-Type": "application/json"
       },
-      body: JSON.stringify(payload)
+      body: JSON.stringify(messagePayload)
     });
 
     const trackedPromise: TrackedPromise = {
@@ -256,7 +258,14 @@ export default class MicrosoftTeamsDestination implements LogDestination {
     };
 
     promise
-      .catch((error: unknown) => console.error(`Failed to log message to ${this.name}`, "--->", error))
+      .catch((error: unknown) =>
+        console.error(
+          `${colors.fgRed}Failed to log message to ${this.name}. Message:${colors.reset}`,
+          messagePayload,
+          `${colors.fgRed}--->${colors.reset}`,
+          error
+        )
+      )
       .finally((): void => {
         trackedPromise.isSettled = true;
       });

--- a/src/tests/destination-betterstack.test.ts
+++ b/src/tests/destination-betterstack.test.ts
@@ -104,4 +104,33 @@ describe("BetterStack log destination", () => {
       assert.ok(false, `Default log level should be supported, but error occurred: ${(error as Error).message}`);
     }
   });
+
+  it("should catch and log errors during message POST request", () => {
+    process.env["BETTERSTACK_URL"] = "https://example.betterstack.com";
+    process.env["BETTERSTACK_TOKEN"] = "example-token";
+
+    const betterStackInstance = new BetterStack(minimalPackage);
+
+    // Simulate an error during the POST request by mocking the fetch function
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new Error("Simulated network error");
+    };
+
+    const messageObject: MessageObject = {
+      messageTemplate: "Test message for error handling",
+      message: "Test message for error handling",
+      properties: {}
+    };
+
+    try {
+      betterStackInstance.log(messageObject, "WARN");
+      assert.ok(true, "Error during POST request should be caught and logged");
+    } catch (error) {
+      assert.ok(false, `Error during POST request should be caught and logged, but error occurred: ${(error as Error).message}`);
+    } finally {
+      // Restore the original fetch function
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/src/types/LogDestination.types.ts
+++ b/src/types/LogDestination.types.ts
@@ -54,7 +54,7 @@ import type { LogLevel, MessageObject, TrackedPromise } from "./log.types";
  *       };
  *     }
  *
- *     const payload: CustomPayloadType = this.createPayload<CustomPayloadType>(messageObject, level);
+ *     const messagePayload: CustomPayloadType = this.createPayload<CustomPayloadType>(messageObject, level);
  *
  *     // Custom logging logic here
  *
@@ -102,7 +102,7 @@ export interface LogDestination {
    * }
    *
    * // Usage in log method
-   * const payload: CustomPayloadType = this.createPayload<CustomPayloadType>(messageObject, level);
+   * const messagePayload: CustomPayloadType = this.createPayload<CustomPayloadType>(messageObject, level);
    * ```
    *
    * @param messageObject
@@ -122,7 +122,7 @@ export interface LogDestination {
    * <h3>Asynchronous logging</h3>
    * If the destination supports asynchronous logging, it should return a **TrackedPromise** that resolves when logging is complete:
    * ```TypeScript
-   * const payload: CustomPayloadType = this.createPayload<CustomPayloadType>(messageObject, level);
+   * const messagePayload: CustomPayloadType = this.createPayload<CustomPayloadType>(messageObject, level);
    *
    * const logPromise = fetch(endpointUrl, {
    *   method: 'POST',
@@ -140,10 +140,17 @@ export interface LogDestination {
    *
    * // CAUTION: ALWAYS catch any errors that may happen. An uncaught exception can kill the app using loglady 🪵
    * promise
-   *  .catch((error: unknown) => console.error(`Failed to log message to ${this.name}`, "--->", error))
-   *  .finally((): void => {
-   *    trackedPromise.isSettled = true;
-   *  });
+   *   .catch((error: unknown) =>
+   *     console.error(
+   *       `${colors.fgRed}Failed to log message to ${this.name}. Message:${colors.reset}`,
+   *       messagePayload,
+   *       `${colors.fgRed}--->${colors.reset}`,
+   *       error
+   *     )
+   *   )
+   *   .finally((): void => {
+   *     trackedPromise.isSettled = true;
+   *   });
    *
    * return trackedPromise;
    * ```
@@ -151,7 +158,7 @@ export interface LogDestination {
    * <h3>Synchronous logging</h3>
    * If the destination does not support asynchronous logging, it should return a resolved **TrackedPromise** after logging is complete:
    * ```TypeScript
-   * const payload: CustomPayloadType = this.createPayload<CustomPayloadType>(messageObject, level);
+   * const messagePayload: CustomPayloadType = this.createPayload<CustomPayloadType>(messageObject, level);
    *
    * // logging logic here
    *

--- a/src/types/log.types.ts
+++ b/src/types/log.types.ts
@@ -6,6 +6,14 @@ export type CallingInfo = {
   columnNumber: number;
 };
 
+export type ConsoleColors = {
+  fgCyan: string;
+  fgRed: string;
+  fgWhite: string;
+  fgYellow: string;
+  reset: string;
+};
+
 export type LogLevel = "debug" | "info" | "warn" | "error" | "DEBUG" | "INFO" | "WARN" | "ERROR";
 
 export type MessageParameter = string | number | bigint | boolean | object | [] | undefined | null;


### PR DESCRIPTION
### Maintenance commits:
- chore: Log out the `messagePayload` as well when a destination promise fails (2cd1a96)
